### PR TITLE
method,metric: make straitjacket'ed structs public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
-straitjacket_macro = { git = "https://github.com/3scale-rs/straitjacket_macro", rev = "5469b195b4ec76a8f6c4b0a14d98f2d49577ac69" }
+straitjacket_macro = { git = "https://github.com/3scale-rs/straitjacket_macro", branch = "master" }
 reqwest = { version = "*", features = ["blocking", "json"] }
 url = "^2"
 http = "^0.2"

--- a/src/api/v0/service/method.rs
+++ b/src/api/v0/service/method.rs
@@ -2,12 +2,12 @@ use serde::{Deserialize, Serialize};
 use straitjacket_macro::straitjacket;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct Metadata;
+pub struct Metadata;
 
 #[straitjacket]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 // A service method
-struct Method {
+pub struct Method {
     id: String,
     name: String,
     system_name: String,

--- a/src/api/v0/service/metric.rs
+++ b/src/api/v0/service/metric.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use straitjacket_macro::straitjacket;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct Metadata;
+pub struct Metadata;
 
 #[straitjacket]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION

This is currently required by the macro to provide accessors. We can still
control visibility via other mechanisms.