### PR TITLE
Update mod.rs to not require api_backend and endpoint

### DIFF
--- a/src/api/v0/service/proxy/configs.rs
+++ b/src/api/v0/service/proxy/configs.rs
@@ -663,9 +663,9 @@ mod tests {
                     id: 1,
                     tenant_id: 2,
                     service_id: 3,
-                    api_backend: url::Url::parse("https://3scale.net")
-                        .expect("failed to parse url"),
-                    endpoint: url::Url::parse("https://3scale.net").expect("failed to parse url"),
+                    api_backend: Some(url::Url::parse("https://3scale.net")
+                        .expect("failed to parse url")),
+                    endpoint: Some(url::Url::parse("https://3scale.net").expect("failed to parse url")),
                     hostname_rewrite: Some("/".into()),
                     authentication_method: AuthenticationMode::APIKey,
                     auth_user_key: "abc".into(),
@@ -922,9 +922,9 @@ mod tests {
                     id: 1,
                     tenant_id: 2,
                     service_id: 3,
-                    api_backend: url::Url::parse("https://3scale.net")
-                        .expect("failed to parse url"),
-                    endpoint: url::Url::parse("https://3scale.net").expect("failed to parse url"),
+                    api_backend: Some(url::Url::parse("https://3scale.net")
+                        .expect("failed to parse url")),
+                    endpoint: Some(url::Url::parse("https://3scale.net").expect("failed to parse url")),
                     hostname_rewrite: Some("/".into()),
                     authentication_method: AuthenticationMode::APIKey,
                     auth_user_key: "abc".into(),

--- a/src/api/v0/service/proxy/mod.rs
+++ b/src/api/v0/service/proxy/mod.rs
@@ -162,11 +162,11 @@ pub struct Proxy {
     id: u64,
     tenant_id: u64,
     service_id: u64,
-    #[serde(deserialize_with = "parse_url", serialize_with = "serialize_url")]
-    endpoint: url::Url,
+    #[serde(deserialize_with = "parse_url_opt", skip_serializing)]
+    endpoint: Option<url::Url>,
     deployed_at: Option<String>,
-    #[serde(deserialize_with = "parse_url", serialize_with = "serialize_url")]
-    api_backend: url::Url,
+    #[serde(deserialize_with = "parse_url_opt", skip_serializing)]
+    api_backend: Option<url::Url>,
     auth_app_key: String,
     auth_app_id: String,
     auth_user_key: String,
@@ -224,7 +224,7 @@ impl Proxy {
         self.service_id
     }
 
-    pub fn endpoint(&self) -> &url::Url {
+    pub fn endpoint(&self) -> &Option<url::Url> {
         &self.endpoint
     }
 
@@ -232,7 +232,7 @@ impl Proxy {
         self.endpoint_port
     }
 
-    pub fn api_backend(&self) -> &url::Url {
+    pub fn api_backend(&self) -> &Option<url::Url> {
         &self.api_backend
     }
 


### PR DESCRIPTION
As far as I know, api_backend is no longer a required field, this causes problems as it simply cannot deserialize a response that doesn't contain it.

Sadly I am not very versed in rust and so this the best I could do, I could make it a Option because of custom serializer.